### PR TITLE
Various improvements

### DIFF
--- a/se_module/sybase.fc
+++ b/se_module/sybase.fc
@@ -1,6 +1,8 @@
 #
 /(lib|etc)/systemd/system/sybase(-[^/@]+)?@?\..*        gen_context(system_u:object_r:sybase_unit_file_t,s0)
 #
+/opt/sybase(/.*)?                  						gen_context(system_u:object_r:sybase_usr_t,s0)
+#
 /opt/sybase(/.*)?/(bin|scripts?)(/.*)?                  gen_context(system_u:object_r:sybase_bin_t,s0)
 /opt/sybase/.*/[^/]+\.(b|ba|c|k|z)?sh               --  gen_context(system_u:object_r:sybase_bin_t,s0)
 #
@@ -9,6 +11,8 @@
 #
 /opt/sybase(/.*)?/conf(ig)?(/.*)?                       gen_context(system_u:object_r:sybase_conf_t,s0)
 /opt/sybase(/.*)?/[^/]+\.(env|cfg|conf|properties)  --  gen_context(system_u:object_r:sybase_conf_t,s0)
+/opt/sybase(/.*)?/sysam/[^/]+\.properties  			--  gen_context(system_u:object_r:sybase_dynconf_t,s0)
+/opt/sybase(/.*)?/(ASE[^/]*|ase)/[^/]+\.(krg|bak)  	--  gen_context(system_u:object_r:sybase_dynconf_t,s0)
 #
 /opt/sybase(/.*)?/data(/.*)?                            gen_context(system_u:object_r:sybase_db_t,s0)
 /var/opt/sybase(/.*)?                                   gen_context(system_u:object_r:sybase_db_t,s0)
@@ -16,9 +20,9 @@
 /opt/sybase(/.*)?/logs?(/.*)?                           gen_context(system_u:object_r:sybase_log_t,s0)
 /var/log/sybase(/.*)?                                   gen_context(system_u:object_r:sybase_log_t,s0)
 #
-/opt/sybase/(ASE|ase)(.*)?/bin/[^/]+server          --  gen_context(system_u:object_r:sybase_exec_t,s0)
+/opt/sybase/(ASE[^/]*|ase)(/.*)?/bin/[^/]+server    --  gen_context(system_u:object_r:sybase_exec_t,s0)
 #
-/opt/sybase/(ASE|ase)(.*)?/install(/.*)?                gen_context(system_u:object_r:sybase_run_t,s0)
+/opt/sybase/(ASE[^/]*|ase)(/.*)?/install(/.*)?          gen_context(system_u:object_r:sybase_run_t,s0)
 /opt/sybase(/.*)?/interfaces                        --  gen_context(system_u:object_r:sybase_run_t,s0)
 #
 /opt/sybase(/.*)?/(sample|[Tt]emplate|xml)s?(/.*)?      gen_context(system_u:object_r:sybase_var_t,s0)

--- a/se_module/sybase.if
+++ b/se_module/sybase.if
@@ -1,6 +1,33 @@
 #######################################
 ## <summary>
 ##      This interface allows a domain to 
+##      use Sybase binaries and libraries as a DB client
+## </summary>
+## <desc>
+##      <p>
+##      This interface grants the sybase_client_domain
+##      attribute.
+##      </p>
+## </desc>
+## <param name="domain">
+##      <summary>
+##      The domain to grant connect permission to.
+##      </summary>
+## </param>
+
+interface(`sybase_client',`
+        gen_require(`
+                type            $1_t;
+                
+                attribute       sybase_client_domain;
+        ')
+
+        typeattribute   $1_t    sybase_client_domain;
+')
+
+#######################################
+## <summary>
+##      This interface allows a domain to 
 ##      connect to a Sybase DB/server via the network
 ## </summary>
 ## <desc>
@@ -15,7 +42,7 @@
 ##      </summary>
 ## </param>
 
-interface(`sybase_client',`
+interface(`sybase_connect',`
         gen_require(`
                 type $1_t;
                 

--- a/se_module/sybase.if
+++ b/se_module/sybase.if
@@ -18,7 +18,8 @@
 interface(`sybase_client',`
         gen_require(`
                 type $1_t;
-                type sybase_port_t;
+                
+                type            sybase_port_t;
         ')
 
         allow   $1_t  sybase_port_t:tcp_socket    name_connect;

--- a/se_module/sybase.te
+++ b/se_module/sybase.te
@@ -1,4 +1,4 @@
-policy_module(sybase, 0.2.1)
+policy_module(sybase, 0.3.0)
 
 ########################################
 #
@@ -13,9 +13,11 @@ attribute sybase_file_type;
 attribute sybase_exec_type;
 attribute sybase_port_type;
 
+type sybase_usr_t;
 type sybase_bin_t;
 type sybase_lib_t;
 type sybase_conf_t;
+type sybase_dynconf_t;
 type sybase_var_t;
 type sybase_run_t;
 type sybase_tmp_t;
@@ -40,11 +42,17 @@ typeattribute sybase_exec_t sybase_file_type;
 corecmd_executable_file(sybase_bin_t)
 typeattribute sybase_bin_t sybase_file_type;
 
+files_type(sybase_usr_t)
+typeattribute sybase_usr_t sybase_file_type;
+
 files_type(sybase_lib_t)
 typeattribute sybase_lib_t sybase_file_type;
 
-logging_log_file(sybase_conf_t)
+files_config_file(sybase_conf_t)
 typeattribute sybase_conf_t sybase_file_type;
+
+files_config_file(sybase_dynconf_t)
+typeattribute sybase_dynconf_t sybase_file_type;
 
 files_type(sybase_var_t)
 typeattribute sybase_var_t sybase_file_type;
@@ -55,7 +63,7 @@ typeattribute sybase_run_t sybase_file_type;
 files_tmp_file(sybase_tmp_t)
 typeattribute sybase_tmp_t sybase_file_type;
 
-files_config_file(sybase_log_t)
+logging_log_file(sybase_log_t)
 typeattribute sybase_log_t sybase_file_type;
 
 files_type(sybase_db_t)
@@ -117,6 +125,9 @@ files_search_locks(sybase_db_domain)
 libs_exec_lib_files(sybase_db_domain)
 libs_use_shared_libs(sybase_db_domain)
 
+files_list_tmp(sybase_db_domain)
+files_list_var(sybase_db_domain)
+
 fs_read_cgroup_files(sybase_db_domain)
 
 fs_getattr_xattr_fs(sybase_db_domain)
@@ -152,6 +163,8 @@ allow sybase_db_domain  sybase_db_type:dir          rw_dir_perms;
 allow sybase_db_domain  sybase_db_type:file         manage_file_perms;
 allow sybase_db_domain  sybase_db_type:lnk_file     manage_lnk_file_perms;
 
+allow sybase_db_domain  sybase_dynconf_t:file       manage_file_perms;
+
 allow sybase_db_domain  sybase_bin_t:file           exec_file_perms;
 allow sybase_db_domain  sybase_lib_t:file           exec_file_perms;
 
@@ -168,6 +181,9 @@ allow sybase_db_domain  sybase_port_type:tcp_socket { name_bind name_connect };
 #
 ##
 #
+
+allow sybase_db_domain  self:process    { execmem strlimit };
+
 allow sybase_db_domain  sybase_db_domain:tcp_socket           create_stream_socket_perms;
 allow sybase_db_domain  sybase_db_domain:netlink_route_socket { bind create getattr nlmsg_read };
 
@@ -193,6 +209,7 @@ allow confined_admindomain  sybase_db_type:file         getattr_file_perms;
 allow confined_admindomain  sybase_db_type:lnk_file     read_lnk_file_perms;
 
 allow confined_admindomain  sybase_conf_t:file          read_file_perms;
+allow confined_admindomain  sybase_dynconf_t:file       read_file_perms;
 allow confined_admindomain  sybase_var_t:file           read_file_perms;
 allow confined_admindomain  sybase_run_t:file           read_file_perms;
 allow confined_admindomain  sybase_bin_t:file           exec_file_perms;
@@ -202,6 +219,10 @@ allow confined_admindomain  sybase_log_t:file           read_file_perms;
 allow dbadm_t sybase_conf_t:dir           manage_dir_perms;
 allow dbadm_t sybase_conf_t:file          manage_file_perms;
 allow dbadm_t sybase_conf_t:lnk_file      manage_lnk_file_perms;
+
+allow dbadm_t sybase_dynconf_t:dir        manage_dir_perms;
+allow dbadm_t sybase_dynconf_t:file       manage_file_perms;
+allow dbadm_t sybase_dynconf_t:lnk_file   manage_lnk_file_perms;
 
 allow dbadm_t sybase_var_t:dir            manage_dir_perms;
 allow dbadm_t sybase_var_t:file           manage_file_perms;
@@ -238,7 +259,9 @@ filetrans_pattern(sybase_db_domain,       sybase_tmp_t, sybase_tmp_t, { dir file
 filetrans_pattern(sybase_db_domain,       sybase_run_t, sybase_run_t, { dir file lnk_file sock_file fifo_file })
 
 fs_tmpfs_filetrans(sybase_db_domain, sybase_tmp_t, { dir file lnk_file })
+userdom_tmp_filetrans_user_tmp(sybase_t, { dir file lnk_file sock_file fifo_file })
 
+filetrans_add_pattern(sybase_db_domain,   sybase_usr_t, sybase_dynconf_t, file )
 filetrans_add_pattern(sybase_db_domain,   sybase_log_t, sybase_log_t, { dir file lnk_file })
 
 filetrans_add_pattern(dbadm_t,  sybase_var_t,   sybase_var_t,   { dir file lnk_file })

--- a/se_module/sybase.te
+++ b/se_module/sybase.te
@@ -7,6 +7,7 @@ policy_module(sybase, 0.3.0)
 ########################################
 
 attribute sybase_db_domain;
+attribute sybase_client_domain;
 
 attribute sybase_db_type;
 attribute sybase_file_type;
@@ -84,6 +85,7 @@ gen_require(`
     attribute unconfined_domain_type;
     attribute initrc_transition_domain;
     attribute confined_admindomain;
+    attribute domain;
 
     type      unconfined_t;
     type      unconfined_service_t;
@@ -270,6 +272,25 @@ filetrans_add_pattern(dbadm_t,  sybase_conf_t,  sybase_conf_t,  { dir file lnk_f
 
 ########################################
 #
+# Permissions for client domains
+#
+########################################
+
+allow   sybase_client_domain    sybase_port_t:tcp_socket    name_connect;
+    
+allow   sybase_client_domain    sybase_file_type:{ dir file lnk_file }    getattr;
+allow   sybase_client_domain    sybase_file_type:lnk_file                 read_lnk_file_perms;
+
+allow   sybase_client_domain    sybase_usr_t:dir          list_dir_perms;
+
+allow   sybase_client_domain    sybase_lib_t:dir          list_dir_perms;
+allow   sybase_client_domain    sybase_lib_t:file         read_file_perms;
+
+allow   sybase_client_domain    sybase_bin_t:dir          list_dir_perms;
+allow   sybase_client_domain    sybase_bin_t:file         exec_file_perms;
+
+########################################
+#
 # Force transition to sybase_t domain
 #
 ########################################
@@ -279,5 +300,9 @@ domtrans_pattern(initrc_transition_domain,  sybase_exec_t,  sybase_t)
 
 allow initrc_transition_domain  sybase_db_domain:process2       nosuid_transition;
 allow initrc_t                  sybase_db_domain:process2       nosuid_transition;
+
+allow domain                    sybase_usr_t:dir        search_dir_perms;
+allow domain                    sybase_usr_t:file       getattr;
+allow domain                    sybase_usr_t:lnk_file   getattr;
 
 permissive sybase_t;

--- a/se_module/sybase.te
+++ b/se_module/sybase.te
@@ -182,7 +182,7 @@ allow sybase_db_domain  sybase_port_type:tcp_socket { name_bind name_connect };
 ##
 #
 
-allow sybase_db_domain  self:process    { execmem strlimit };
+allow sybase_db_domain  self:process    { execmem setrlimit };
 
 allow sybase_db_domain  sybase_db_domain:tcp_socket           create_stream_socket_perms;
 allow sybase_db_domain  sybase_db_domain:netlink_route_socket { bind create getattr nlmsg_read };

--- a/se_module/test.te
+++ b/se_module/test.te
@@ -1,0 +1,13 @@
+policy_module(test, 0.0.1)
+
+########################################
+#
+# Test sybase.if compilation
+#
+########################################
+
+type sybase_test1_t;
+type sybase_test2_t;
+
+sybase_client(sybase_test1)
+sybase_connect(sybase_test1)


### PR DESCRIPTION
Closes #6

- Introduces `sybase_usr_t` and `sybase_dynconf_t` types,
- Add `execmem` and `setrlimit` process permissions,
- Set `sybase_usr_t` type on `/opt/sybase`,
- Allow for use of `/tmp` with transition to `user_tmp_t`,
- Fix some typos.